### PR TITLE
Add directory name log message.

### DIFF
--- a/btrfs-snp
+++ b/btrfs-snp
@@ -69,7 +69,7 @@ chmod +x /etc/cron.hourly/$BIN"
     local LATEST=$( sed -r "s|.*_(.*_.*)|\\1|;s|_([0-9]{2})([0-9]{2})([0-9]{2})| \\1:\\2:\\3|" <<< "${SNAPS[-1]}" )
     LATEST=$( date +%s -d "$LATEST" ) || return 1
 
-    [[ $(( LATEST + TIME )) -gt $( date +%s ) ]] && { echo "No new snapshot needed for $TAG"; return 0; }
+    [[ $(( LATEST + TIME )) -gt $( date +%s ) ]] && { echo "No new snapshot needed for $TAG in $DIR"; return 0; }
   }
 
   ## do it


### PR DESCRIPTION
When running `btrfs-snp` commands via a cron or systemd timer, it can be helpful to know which directory did not need a new snapshot created - especially in cases where many `btrfs-snp` commands are run in a single job.