### PR TITLE
Add margin option for time comparison.

### DIFF
--- a/btrfs-snp
+++ b/btrfs-snp
@@ -33,7 +33,6 @@ function btrfs-snp()
   limit   │ keep <limit> snapshots with this tag. 0 to disable
   seconds │ don't create snapshots before <seconds> have passed from last with this tag. 0 to disable
   destdir │ store snapshot in <destdir>, path absolute or relative to <dir>
-  margin  │ number of seconds to add when comparing <seconds> to previous snapshot time. 0 to disable
 
 Cron example: Hourly snapshot for one day, daily for one week, weekly for one month, and monthly for one year.
 

--- a/btrfs-snp
+++ b/btrfs-snp
@@ -22,7 +22,7 @@ function btrfs-snp()
   local LIMIT="${3:-0}"
   local  TIME="${4:-0}"
   local   DST="${5:-.snapshots}"
-  local MARGIN="${6:-0}"
+  local MARGIN=15 # allow for some seconds of inaccuracy for cron / systemd timers
 
   ## usage
   [[ "$*" == "" ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]] && {

--- a/btrfs-snp
+++ b/btrfs-snp
@@ -22,6 +22,7 @@ function btrfs-snp()
   local LIMIT="${3:-0}"
   local  TIME="${4:-0}"
   local   DST="${5:-.snapshots}"
+  local MARGIN="${6:-0}"
 
   ## usage
   [[ "$*" == "" ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]] && {
@@ -32,6 +33,7 @@ function btrfs-snp()
   limit   │ keep <limit> snapshots with this tag. 0 to disable
   seconds │ don't create snapshots before <seconds> have passed from last with this tag. 0 to disable
   destdir │ store snapshot in <destdir>, path absolute or relative to <dir>
+  margin  │ number of seconds to add when comparing <seconds> to previous snapshot time. 0 to disable
 
 Cron example: Hourly snapshot for one day, daily for one week, weekly for one month, and monthly for one year.
 
@@ -69,7 +71,7 @@ chmod +x /etc/cron.hourly/$BIN"
     local LATEST=$( sed -r "s|.*_(.*_.*)|\\1|;s|_([0-9]{2})([0-9]{2})([0-9]{2})| \\1:\\2:\\3|" <<< "${SNAPS[-1]}" )
     LATEST=$( date +%s -d "$LATEST" ) || return 1
 
-    [[ $(( LATEST + TIME )) -gt $( date +%s ) ]] && { echo "No new snapshot needed for $TAG"; return 0; }
+    [[ $(( LATEST + TIME )) -gt $(( $( date +%s ) + MARGIN )) ]] && { echo "No new snapshot needed for $TAG"; return 0; }
   }
 
   ## do it


### PR DESCRIPTION
This change adds a `MARGIN` option that is added to the time comparison to account for differences in actual time in seconds that cron or timer jobs actually run relative to each other. Use of this option can prevent skipped jobs.

Here is an example using my situation:

I have a `oneshot` systemd service that runs a handful of `btrfs-snp` commands similar to this:

```
...
ExecStart=/usr/local/sbin/btrfs-snp /data daily 7 86400
ExecStart=/usr/local/sbin/btrfs-snp /data weekly 4 604800
ExecStart=/usr/local/sbin/btrfs-snp /data monthly 12 2592000
...
```

via a timer which runs each day at 4am.

```
...
[Timer]
OnCalendar=*-*-* 4:00:00
...
```

Each day, the job may run a few seconds before or after when it ran the day before. For example, here is output from a few recent daily jobs:

```
daily_2020-03-14_040004
daily_2020-03-16_040000
daily_2020-03-17_040004
daily_2020-03-18_040004
```

As you can see, there is a 4 second difference between 03-14 and 03-16 and there is no `daily_` for 03-15.

With this change my service can be updated to give me a 10 second margin to account for minor differences on actual trigger time each day:

```
...
ExecStart=/usr/local/sbin/btrfs-snp /data daily 7 86400 .snapshots 10
ExecStart=/usr/local/sbin/btrfs-snp /data weekly 4 604800 .snapshots 10
ExecStart=/usr/local/sbin/btrfs-snp /data monthly 12 2592000 .snapshots 10
...
```

